### PR TITLE
Remove SQLite dependency from cfssl.go

### DIFF
--- a/cmd/cfssl/cfssl.go
+++ b/cmd/cfssl/cfssl.go
@@ -45,7 +45,6 @@ import (
 
 	_ "github.com/go-sql-driver/mysql" // import to support MySQL
 	_ "github.com/lib/pq"              // import to support Postgres
-	_ "github.com/mattn/go-sqlite3"    // import to support SQLite3
 )
 
 // main defines the cfssl usage and registers all defined commands and flags.


### PR DESCRIPTION
Remove SQLite dependency from cmd/cfssl/cfssl.go because it breaks the build on a number of architectures.